### PR TITLE
feat: add Nethermind as external L2 execution layer option

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -201,13 +201,24 @@ services:
       - "./data/config:/config"
 
   sequencer:
+    # Main sequencer always runs in dual EL mode (internal geth + external NM)
+    image: daniilankushin/nitro:latest
+    depends_on:
+      nethermind-l2:
+        condition: service_healthy
+      geth:
+        condition: service_started
     pid: host # allow debugging
-    image: nitro-node-dev-testnode
     entrypoint: /usr/local/bin/nitro
     ports:
       - "127.0.0.1:8547:8547"
       - "127.0.0.1:8548:8548"
-      - "127.0.0.1:9642:9642"
+    environment:
+      # Always-on dual EL mode: Nitro uses both internal geth and external NM
+      - PR_USE_EXTERNAL_EXECUTION=true
+      # Use correct EL URL for Docker networking
+      - PR_EXTERNAL_EXECUTION_RPC=http://nethermind-arbitrum-local:20545
+      - PR_NETH_RPC_CLIENT_URL=http://nethermind-arbitrum-local:20545
     volumes:
       - "./data/seqdata:/home/user/.arbitrum"
       - "./data/l1keystore:/home/user/l1keystore"
@@ -222,8 +233,6 @@ services:
       - --graphql.enable
       - --graphql.vhosts=*
       - --graphql.corsdomain=*
-    depends_on:
-      - geth
 
   sequencer_b:
     pid: host # allow debugging
@@ -528,6 +537,27 @@ services:
       - --log-level=INFO
     depends_on:
       - redis
+
+  nethermind-l2:
+    image: daniilankushin/nethermind-arbitrum:latest
+    container_name: nethermind-arbitrum-local
+    ports:
+      - "20545:20545"
+      - "20551:20551"
+    volumes:
+      - ./nethermind_data:/app/nethermind_db
+    command:
+      - -c
+      - arbitrum-local
+      - --JsonRpc.Host
+      - 0.0.0.0
+      - --JsonRpc.EngineHost
+      - 0.0.0.0
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 5 bash -c '</dev/tcp/localhost/20545' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   l1data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -201,11 +201,9 @@ services:
       - "./data/config:/config"
 
   sequencer:
-    # Main sequencer always runs in dual EL mode (internal geth + external NM)
+    # Main sequencer runs with optional external NM (controlled by script)
     image: daniilankushin/nitro:latest
     depends_on:
-      nethermind-l2:
-        condition: service_healthy
       geth:
         condition: service_started
     pid: host # allow debugging
@@ -214,11 +212,10 @@ services:
       - "127.0.0.1:8547:8547"
       - "127.0.0.1:8548:8548"
     environment:
-      # Always-on dual EL mode: Nitro uses both internal geth and external NM
-      - PR_USE_EXTERNAL_EXECUTION=true
-      # Use correct EL URL for Docker networking
-      - PR_EXTERNAL_EXECUTION_RPC=http://nethermind-arbitrum-local:20545
-      - PR_NETH_RPC_CLIENT_URL=http://nethermind-arbitrum-local:20545
+      # External execution configuration set by script based on --nethermind-l2 flag
+      - PR_USE_EXTERNAL_EXECUTION=${USE_EXTERNAL_EXECUTION:-false}
+      - PR_EXTERNAL_EXECUTION_RPC=${EXTERNAL_EXECUTION_RPC:-}
+      - PR_NETH_RPC_CLIENT_URL=${NETH_RPC_CLIENT_URL:-}
     volumes:
       - "./data/seqdata:/home/user/.arbitrum"
       - "./data/l1keystore:/home/user/l1keystore"
@@ -545,7 +542,7 @@ services:
       - "20545:20545"
       - "20551:20551"
     volumes:
-      - ./nethermind_data:/app/nethermind_db
+      - nethermind-data:/app/nethermind_db
     command:
       - -c
       - arbitrum-local
@@ -581,3 +578,4 @@ volumes:
   das-committee-b-data:
   das-mirror-data:
   timeboost-auctioneer-data:
+  nethermind-data:


### PR DESCRIPTION
Fixes [#93](https://github.com/NethermindEth/nethermind-arbitrum/issues/93)
- Add --nethermind-l2 flag to enable Nethermind as external EL
- Configure sequencer to run in dual EL mode with both internal geth and external Nethermind
- Add nethermind-l2 service with health checks and proper networking
- Clean up nethermind data directory on force init
- Update sequencer dependencies and environment variables for external execution support

This enables testing Arbitrum with Nethermind as the L2 execution layer while maintaining backward compatibility with geth-only setup.