### PR TITLE
Node Strategy Fix

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -200,7 +200,6 @@ function writeConfigs(argv: any) {
         "node": {
             "bold": {
                 "rpc-block-number": "latest",
-                "strategy": "makeNodes",
                 "assertion-posting-interval": "10s"
             },
             "staker": {
@@ -216,7 +215,6 @@ function writeConfigs(argv: any) {
                 "enable": false,
                 "staker-interval": "10s",
                 "make-assertion-interval": "10s",
-                "strategy": "MakeNodes",
             },
             "sequencer": false,
             "dangerous": {


### PR DESCRIPTION
This is needed after latest Nitro update in order to build properly without issues.

They removed strategy from BoldConfig
https://github.com/NethermindEth/arbitrum-nitro/blob/nethermind/staker/bold/bold_staker.go#L61